### PR TITLE
Fix segfault when failing to read random numbers.

### DIFF
--- a/src/nolegacy/crypto.c
+++ b/src/nolegacy/crypto.c
@@ -46,10 +46,10 @@ void randomize(void *vout, size_t outlen) {
 	char *out = vout;
 
 	while(outlen) {
-		size_t len = read(random_fd, out, outlen);
+		ssize_t len = read(random_fd, out, outlen);
 
 		if(len <= 0) {
-			if(errno == EAGAIN || errno == EINTR) {
+			if(len == -1 && (errno == EAGAIN || errno == EINTR)) {
 				continue;
 			}
 

--- a/src/openssl/crypto.c
+++ b/src/openssl/crypto.c
@@ -50,10 +50,10 @@ void randomize(void *vout, size_t outlen) {
 	char *out = vout;
 
 	while(outlen) {
-		size_t len = read(random_fd, out, outlen);
+		ssize_t len = read(random_fd, out, outlen);
 
 		if(len <= 0) {
-			if(errno == EAGAIN || errno == EINTR) {
+			if(len == -1 && (errno == EAGAIN || errno == EINTR)) {
 				continue;
 			}
 


### PR DESCRIPTION
Because the result of read() was incorrectly stored in an unsigned
variable, an error reading from the random number generator device would
result in an infinite loop that would start writing out of bounds and
eventually corrupt the stack.